### PR TITLE
Add service worker for offline support

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,82 @@
+/// <reference types="@sveltejs/kit" />
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
+import { build, files, version } from '$service-worker';
+
+const sw = /** @type {ServiceWorkerGlobalScope} */ (/** @type {unknown} */ (self));
+
+// Create a unique cache name for this deployment
+const CACHE = `cache-${version}`;
+
+const ASSETS = [
+	...build, // the app itself
+	...files // everything in `static`
+];
+
+sw.addEventListener('install', (event) => {
+	// Create a new cache and add all files to it
+	async function addFilesToCache() {
+		const cache = await caches.open(CACHE);
+		await cache.addAll(ASSETS);
+	}
+
+	event.waitUntil(addFilesToCache());
+});
+
+sw.addEventListener('activate', (event) => {
+	// Remove previous cached data from disk
+	async function deleteOldCaches() {
+		for (const key of await caches.keys()) {
+			if (key !== CACHE) await caches.delete(key);
+		}
+	}
+
+	event.waitUntil(deleteOldCaches());
+});
+
+sw.addEventListener('fetch', (event) => {
+	// Ignore POST requests etc
+	if (event.request.method !== 'GET') return;
+
+	async function respond() {
+		const url = new URL(event.request.url);
+		const cache = await caches.open(CACHE);
+
+		// `build`/`files` can always be served from the cache
+		if (ASSETS.includes(url.pathname)) {
+			const cachedResponse = await cache.match(url.pathname);
+			if (cachedResponse) {
+				return cachedResponse;
+			}
+		}
+
+		// For everything else, try the network first, but
+		// fall back to the cache if we're offline
+		try {
+			const response = await fetch(event.request);
+
+			// If we're offline, fetch will throw
+			const isNotExtension = url.protocol === 'http:' || url.protocol === 'https:';
+			const isSuccess = response.status === 200;
+
+			if (isNotExtension && isSuccess) {
+				cache.put(event.request, response.clone());
+			}
+
+			return response;
+		} catch {
+			// Fall back to cache
+			const cachedResponse = await cache.match(event.request);
+			if (cachedResponse) {
+				return cachedResponse;
+			}
+
+			// If there's no cache, return an offline page or error
+			return new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
+		}
+	}
+
+	event.respondWith(respond());
+});


### PR DESCRIPTION
## Summary
- Adds service worker using SvelteKit's `$service-worker` module
- Pre-caches all build assets and static files during installation
- Implements network-first strategy with cache fallback for offline use
- Cleans up old caches when new versions are deployed

Closes #6

## Test plan
- [ ] Build and deploy the app
- [ ] Open app and verify service worker registers (check DevTools > Application > Service Workers)
- [ ] Load the app normally, then go offline (DevTools > Network > Offline)
- [ ] Verify app still works offline (OTP codes should continue generating)
- [ ] Deploy a new version and verify old caches are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)