### PR TITLE
Apply style tweaks to match logo branding

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -99,7 +99,8 @@
 		gap: 0.75rem;
 		padding: 1rem 1.25rem;
 		background: var(--card-bg);
-		border-radius: 0.75rem;
+		border-radius: var(--radius-lg);
+		corner-shape: squircle;
 		cursor: pointer;
 		transition: transform 0.15s, box-shadow 0.15s;
 		position: relative;
@@ -128,7 +129,8 @@
 		width: 40px;
 		height: 40px;
 		background: var(--accent);
-		border-radius: 10px;
+		border-radius: var(--radius-md);
+		corner-shape: squircle;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -174,10 +176,6 @@
 		flex-shrink: 0;
 	}
 
-	.otp.expiring {
-		color: var(--error);
-	}
-
 	.settings-link {
 		display: flex;
 		align-items: center;
@@ -206,18 +204,14 @@
 		right: 0;
 		height: 3px;
 		background: var(--border);
-		border-radius: 0 0 0.75rem 0.75rem;
+		border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 		overflow: hidden;
 	}
 
 	.timer-bar-progress {
 		height: 100%;
 		background: var(--accent);
-		border-radius: 0 0 0 0.75rem;
-	}
-
-	.timer-bar.expiring .timer-bar-progress {
-		background: var(--error);
+		border-radius: 0 0 0 var(--radius-lg);
 	}
 
 	.copied-toast {

--- a/src/lib/components/UnlockScreen.svelte
+++ b/src/lib/components/UnlockScreen.svelte
@@ -386,11 +386,12 @@
 
 	.unlock-card {
 		background: var(--card-bg);
-		border-radius: 1rem;
+		border-radius: var(--radius-lg);
+		corner-shape: squircle;
 		padding: 2rem;
 		width: 100%;
 		max-width: 400px;
-		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 	}
 
 	.logo {
@@ -438,6 +439,7 @@
 		justify-content: center;
 		gap: 0.75rem;
 		padding: 1rem;
+		margin-top: 1.25rem;
 		background: var(--accent);
 		color: white;
 		border: none;
@@ -481,6 +483,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;
+		margin-top: 0.5rem;
 	}
 
 	.input-group {
@@ -601,6 +604,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.5rem;
+		margin-top: 1.25rem;
 	}
 
 	.biometric-btn-placeholder {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -39,8 +39,12 @@
 		--text-primary: #ffffff;
 		--text-secondary: #a0a0a0;
 		--text-muted: #666666;
-		--accent: #6366f1;
+		--accent: hsl(37, 96%, 61%);
+		--accent-secondary: hsl(239, 52%, 45%);
 		--error: #ef4444;
+		--radius-sm: 0.375rem;
+		--radius-md: 0.5rem;
+		--radius-lg: 0.75rem;
 
 		background: var(--bg);
 		color: var(--text-primary);
@@ -55,7 +59,8 @@
 		--text-primary: #171717;
 		--text-secondary: #525252;
 		--text-muted: #a3a3a3;
-		--accent: #6366f1;
+		--accent: hsl(37, 90%, 50%);
+		--accent-secondary: hsl(239, 52%, 37%);
 		--error: #dc2626;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -137,11 +137,12 @@
 
 	.loading-card {
 		background: var(--card-bg);
-		border-radius: 1rem;
+		border-radius: var(--radius-lg);
+		corner-shape: squircle;
 		padding: 2rem;
 		width: 100%;
 		max-width: 400px;
-		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 		text-align: center;
 	}
 

--- a/src/routes/account/[id]/+page.svelte
+++ b/src/routes/account/[id]/+page.svelte
@@ -558,10 +558,6 @@
 		transition: color 0.3s;
 	}
 
-	.otp-value.expiring {
-		color: var(--error);
-	}
-
 	.timer-bar {
 		position: absolute;
 		bottom: 0;
@@ -574,10 +570,6 @@
 	.timer-bar-progress {
 		height: 100%;
 		background: var(--accent);
-	}
-
-	.timer-bar.expiring .timer-bar-progress {
-		background: var(--error);
 	}
 
 	.qr-card {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -5,7 +5,7 @@
 	"start_url": "/",
 	"display": "standalone",
 	"background_color": "#0f0f0f",
-	"theme_color": "#6366f1",
+	"theme_color": "#fbb03b",
 	"icons": [
 		{
 			"src": "/icon-512.png",


### PR DESCRIPTION
## Summary

Addresses the style tweaks from issue #12 to better match the logo branding and improve visual polish.

### Colors
- Updated accent color from indigo (#6366f1) to orange/gold `hsl(37, 96%, 61%)` to match the logo
- Added `--accent-secondary` variable with dark blue `hsl(239, 52%, 45%)`
- Updated manifest.json theme_color to `#fbb03b`
- Removed red coloring from timer bars - the dwindling bar provides sufficient feedback

### Gaps/Margins
- Added `margin-top: 1.25rem` to biometric button on lock screen
- Added `margin-top: 0.5rem` to form for spacing when biometrics unavailable
- Added `margin-top: 1.25rem` to biometric placeholder

### Drop Shadows
- Reduced lock screen card shadow from `0 4px 24px rgba(0,0,0,0.2)` to `0 2px 8px rgba(0,0,0,0.1)`

### Border Radius
- Added CSS variables for consistent sizing (`--radius-sm`, `--radius-md`, `--radius-lg`)
- Reduced overall border radii from 1rem to 0.75rem
- Added `corner-shape: squircle` for smoother corners (progressive enhancement)

Closes #12

## Test plan
- [ ] Verify accent color matches the logo orange
- [ ] Check lock screen spacing between elements
- [ ] Verify drop shadow is subtler
- [ ] Test in both light and dark modes
- [ ] Verify timer bars no longer turn red when expiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)