### PR TITLE
Add explanation about secrets storage

### DIFF
--- a/src/lib/components/UnlockScreen.svelte
+++ b/src/lib/components/UnlockScreen.svelte
@@ -370,6 +370,8 @@
 						Create Vault
 					{/if}
 				</button>
+
+				<p class="storage-info">Your secrets are kept on this device and are encrypted using your passphrase.</p>
 			</form>
 		{/if}
 	</div>
@@ -576,6 +578,13 @@
 		font-size: 0.875rem;
 		margin: 0;
 		text-align: center;
+	}
+
+	.storage-info {
+		font-size: 0.8125rem;
+		color: var(--text-muted);
+		text-align: center;
+		margin: 1rem 0 0;
 	}
 
 	.submit-btn {


### PR DESCRIPTION
## Summary
- Adds explanatory text below the "Create Vault" button on the unlock screen
- Shows: "Your secrets are kept on this device and are encrypted using your passphrase."

Fixes #16

## Test plan
- [ ] Navigate to the create vault screen (either fresh install or click "+ Add new vault")
- [ ] Verify the explanatory text appears below the "Create Vault" button
- [ ] Verify text is styled subtly (muted color, smaller font)

🤖 Generated with [Claude Code](https://claude.com/claude-code)