### PR TITLE
Apply additional Vercel design guideline fixes

### DIFF
--- a/src/lib/components/SettingsPanel.svelte
+++ b/src/lib/components/SettingsPanel.svelte
@@ -207,6 +207,7 @@
 							bind:value={editedVaultName}
 							onkeydown={handleVaultNameKeydown}
 							placeholder="Vault name…"
+							aria-label="Vault name"
 						/>
 						<button type="button" class="save-btn" onclick={saveVaultName} aria-label="Save">
 							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -310,7 +311,7 @@
 			</div>
 
 			{#if settingsMessage}
-				<p class="settings-message">{settingsMessage}</p>
+				<p class="settings-message" role="status" aria-live="polite">{settingsMessage}</p>
 			{/if}
 
 			<div class="danger-zone">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<meta name="theme-color" content="#0f0f0f" />
 </svelte:head>
 
 <Header />
@@ -21,6 +22,14 @@
 
 	:global(button, a, input, select, [role="button"]) {
 		touch-action: manipulation;
+	}
+
+	:global(html) {
+		color-scheme: dark;
+	}
+
+	:global([data-theme='light'] html) {
+		color-scheme: light;
 	}
 
 	:global(html, body) {


### PR DESCRIPTION
## Summary
Additional fixes based on Vercel design guidelines audit:

- Add `aria-live="polite"` to settings status messages so screen readers announce import/export results
- Add `aria-label` to vault rename input for proper accessibility
- Add `<meta name="theme-color">` to align browser UI with app theme
- Add `color-scheme: dark/light` CSS property for proper system UI integration

## Test plan
- [ ] Import accounts in settings and verify screen readers announce the result
- [ ] Edit vault name and verify the input is properly labeled for assistive tech
- [ ] Check browser address bar/UI matches app theme color on mobile
- [ ] Verify scrollbars and form controls use proper dark/light system theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)