### PR TITLE
Add browser tests with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,7 @@ jobs:
       - run: pnpm test
 
       - run: pnpm check
+
+      - run: pnpm exec playwright install chromium
+
+      - run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ vite.config.ts.timestamp-*
 # dev3000
 /.cursor
 /opencode.json
+test-results/

--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1,0 +1,218 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Toofer', () => {
+	test.beforeEach(async ({ page }) => {
+		// Clear localStorage before each test
+		await page.goto('/');
+		await page.evaluate(() => localStorage.clear());
+		await page.reload();
+	});
+
+	test.describe('vault creation', () => {
+		test('shows create vault screen when no vaults exist', async ({ page }) => {
+			await page.goto('/');
+
+			await expect(page.getByRole('heading', { name: 'Toofer' })).toBeVisible();
+			await expect(page.getByText('Create a new vault')).toBeVisible();
+			await expect(page.getByLabel('Vault Name')).toBeVisible();
+		});
+
+		test('creates a new vault', async ({ page }) => {
+			await page.goto('/');
+
+			await page.getByLabel('Vault Name').fill('Personal');
+			await page.getByLabel('Passphrase', { exact: true }).fill('testpass123');
+			await page.getByLabel('Confirm Passphrase').fill('testpass123');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+
+			// Should show the main app with empty state
+			await expect(page.getByText('No accounts yet')).toBeVisible();
+		});
+
+		test('shows error when passphrases do not match', async ({ page }) => {
+			await page.goto('/');
+
+			await page.getByLabel('Vault Name').fill('Test');
+			await page.getByLabel('Passphrase', { exact: true }).fill('pass1');
+			await page.getByLabel('Confirm Passphrase').fill('pass2');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+
+			await expect(page.getByText('Passphrases do not match')).toBeVisible();
+		});
+	});
+
+	test.describe('vault unlock', () => {
+		test.beforeEach(async ({ page }) => {
+			// Create a vault first
+			await page.goto('/');
+			await page.getByLabel('Vault Name').fill('Test Vault');
+			await page.getByLabel('Passphrase', { exact: true }).fill('testpass');
+			await page.getByLabel('Confirm Passphrase').fill('testpass');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+			await expect(page.getByText('No accounts yet')).toBeVisible();
+
+			// Lock the vault
+			await page.getByRole('button', { name: 'Lock' }).click();
+		});
+
+		test('unlocks vault with correct passphrase', async ({ page }) => {
+			await expect(page.getByText('Unlock your vault')).toBeVisible();
+			await page.locator('#passphrase').fill('testpass');
+			await page.getByRole('button', { name: 'Unlock' }).click();
+
+			await expect(page.getByText('No accounts yet')).toBeVisible();
+		});
+
+		test('shows error with wrong passphrase', async ({ page }) => {
+			await page.locator('#passphrase').fill('wrongpass');
+			await page.getByRole('button', { name: 'Unlock' }).click();
+
+			await expect(page.getByText('Invalid passphrase')).toBeVisible();
+		});
+	});
+
+	test.describe('account management', () => {
+		test.beforeEach(async ({ page }) => {
+			// Create and unlock a vault
+			await page.goto('/');
+			await page.getByLabel('Vault Name').fill('Test');
+			await page.getByLabel('Passphrase', { exact: true }).fill('test');
+			await page.getByLabel('Confirm Passphrase').fill('test');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+			await expect(page.getByText('No accounts yet')).toBeVisible();
+		});
+
+		test('adds account via manual entry', async ({ page }) => {
+			await page.getByRole('main').getByRole('button', { name: 'Add Account' }).click();
+
+			// Switch to manual entry
+			await page.getByRole('button', { name: 'Enter Manually Instead' }).click();
+
+			// Fill in the form
+			await page.getByLabel('Service Name').fill('GitHub');
+			await page.getByLabel('Account Name').fill('test@example.com');
+			await page.getByLabel('Secret Key').fill('JBSWY3DPEHPK3PXP');
+			await page.getByRole('dialog').getByRole('button', { name: 'Add Account' }).click();
+
+			// Should navigate to account detail page
+			await expect(page.getByRole('heading', { name: 'GitHub' })).toBeVisible();
+			await expect(page.getByText('test@example.com')).toBeVisible();
+		});
+
+		test('shows OTP code on account detail page', async ({ page }) => {
+			// Add an account
+			await page.getByRole('main').getByRole('button', { name: 'Add Account' }).click();
+			await page.getByRole('button', { name: 'Enter Manually Instead' }).click();
+			await page.getByLabel('Service Name').fill('GitHub');
+			await page.getByLabel('Account Name').fill('user@test.com');
+			await page.getByLabel('Secret Key').fill('JBSWY3DPEHPK3PXP');
+			await page.getByRole('dialog').getByRole('button', { name: 'Add Account' }).click();
+
+			// Should show a 6-digit OTP code (formatted as XXX XXX)
+			const otpDisplay = page.locator('.otp-value');
+			await expect(otpDisplay).toBeVisible();
+			await expect(otpDisplay).toHaveText(/^\d{3} \d{3}$/);
+		});
+
+		test('shows account in list after adding', async ({ page }) => {
+			// Add an account
+			await page.getByRole('main').getByRole('button', { name: 'Add Account' }).click();
+			await page.getByRole('button', { name: 'Enter Manually Instead' }).click();
+			await page.getByLabel('Service Name').fill('Google');
+			await page.getByLabel('Account Name').fill('myaccount@gmail.com');
+			await page.getByLabel('Secret Key').fill('HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ');
+			await page.getByRole('dialog').getByRole('button', { name: 'Add Account' }).click();
+
+			// Go back to home
+			await page.getByRole('link', { name: 'Toofer' }).click();
+
+			// Should show the account in the list
+			await expect(page.getByRole('main').getByText('Google')).toBeVisible();
+			await expect(page.getByRole('main').getByText('myaccount@gmail.com')).toBeVisible();
+		});
+
+		test('validates secret key format', async ({ page }) => {
+			await page.getByRole('main').getByRole('button', { name: 'Add Account' }).click();
+			await page.getByRole('button', { name: 'Enter Manually Instead' }).click();
+
+			await page.getByLabel('Service Name').fill('Test');
+			await page.getByLabel('Account Name').fill('test');
+			await page.getByLabel('Secret Key').fill('invalid!secret');
+			await page.getByRole('dialog').getByRole('button', { name: 'Add Account' }).click();
+
+			await expect(page.getByText('Invalid secret key format')).toBeVisible();
+		});
+	});
+
+	test.describe('settings', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/');
+			await page.getByLabel('Vault Name').fill('My Vault');
+			await page.getByLabel('Passphrase', { exact: true }).fill('pass');
+			await page.getByLabel('Confirm Passphrase').fill('pass');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+			await expect(page.getByText('No accounts yet')).toBeVisible();
+		});
+
+		test('opens and closes settings panel', async ({ page }) => {
+			await page.getByRole('button', { name: 'Settings' }).click();
+			await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+			// Close by clicking settings again
+			await page.getByRole('button', { name: 'Settings' }).click();
+			await expect(page.getByRole('heading', { name: 'Settings' })).not.toBeVisible();
+		});
+
+		test('renames vault', async ({ page }) => {
+			await page.getByRole('button', { name: 'Settings' }).click();
+
+			// Click the rename button (shows current vault name)
+			await page.getByRole('button', { name: 'My Vault' }).click();
+
+			// Fill in new name and save
+			await page.getByRole('textbox', { name: 'Vault name' }).fill('Renamed Vault');
+			await page.getByRole('button', { name: 'Save' }).click();
+
+			await expect(page.getByText('Vault renamed')).toBeVisible();
+		});
+	});
+
+	test.describe('navigation', () => {
+		test('locks vault and returns to unlock screen', async ({ page }) => {
+			await page.goto('/');
+			await page.getByLabel('Vault Name').fill('Test');
+			await page.getByLabel('Passphrase', { exact: true }).fill('pass');
+			await page.getByLabel('Confirm Passphrase').fill('pass');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+
+			await page.getByRole('button', { name: 'Lock' }).click();
+
+			await expect(page.getByText('Unlock your vault')).toBeVisible();
+		});
+
+		test('navigates to account detail and back', async ({ page }) => {
+			await page.goto('/');
+			await page.getByLabel('Vault Name').fill('Test');
+			await page.getByLabel('Passphrase', { exact: true }).fill('pass');
+			await page.getByLabel('Confirm Passphrase').fill('pass');
+			await page.getByRole('button', { name: 'Create Vault' }).click();
+
+			// Add account
+			await page.getByRole('main').getByRole('button', { name: 'Add Account' }).click();
+			await page.getByRole('button', { name: 'Enter Manually Instead' }).click();
+			await page.getByLabel('Service Name').fill('Test Service');
+			await page.getByLabel('Account Name').fill('user');
+			await page.getByLabel('Secret Key').fill('JBSWY3DPEHPK3PXP');
+			await page.getByRole('dialog').getByRole('button', { name: 'Add Account' }).click();
+
+			// Should be on detail page
+			await expect(page.getByRole('heading', { name: 'Test Service' })).toBeVisible();
+
+			// Navigate back
+			await page.getByRole('link', { name: 'Toofer' }).click();
+
+			// Should be back on list
+			await expect(page.getByRole('main').getByText('Test Service')).toBeVisible();
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check .",
 		"test": "vitest run",
-		"test:watch": "vitest"
+		"test:watch": "vitest",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.57.0",
 		"@sveltejs/adapter-vercel": "^6.2.0",
 		"@sveltejs/kit": "^2.49.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+	webServer: {
+		command: 'pnpm build && pnpm preview',
+		port: 4173,
+		reuseExistingServer: !process.env.CI
+	},
+	testDir: 'e2e',
+	testMatch: '**/*.test.ts',
+	use: {
+		baseURL: 'http://localhost:4173'
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { browserName: 'chromium' }
+		}
+	]
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@sveltejs/adapter-vercel':
         specifier: ^6.2.0
         version: 6.3.0(@sveltejs/kit@2.49.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.46.3)(vite@7.3.1(@types/node@25.0.7)))(svelte@5.46.3)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.7)))(rollup@4.55.1)
@@ -404,6 +407,11 @@ packages:
 
   '@mapbox/node-pre-gyp@2.0.3':
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -798,6 +806,11 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -924,6 +937,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -1386,6 +1409,10 @@ snapshots:
       - encoding
       - supports-color
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.55.1)':
@@ -1759,6 +1786,9 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1853,6 +1883,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
## Summary
- Configure Playwright with chromium browser
- Add 13 e2e tests covering main user flows:
  - Vault creation and unlock
  - Account management via manual entry
  - OTP code display
  - Settings panel
  - Navigation
- Update CI workflow to run e2e tests

## Test plan
- [x] `pnpm test:e2e` passes locally (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)